### PR TITLE
Added Heroku deploy button.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn project.wsgi --log-file -

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
 stormpath-django-sample
 =======================
 
@@ -18,6 +20,7 @@ Stormpath Django required you to have these environment variables set:
     STORMPATH_API_KEY_ID = "apiKeyId"
     STORMPATH_API_KEY_SECRET = "apiKeySecret"
     STORMPATH_APPLICATION = "https://api.stormpath.com/v1/applications/APP_ID"
+    STORMPATH_ID_SITE_CALLBACK_URI = "http://localhost:8000/stormpath-id-site-callback"
 
 You need to make sure database and other standard Django settings are correct.
 E.g. Chirper has to be specified in INSTALLED_APPS of the project.

--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/avojnovicDk/stormpath-django-sample",
   "logo": "http://docs.stormpath.com/images/heroku/stormpath-icon.svg",
   "keywords": ["django", "stormpath", "heroku", "sample"],
-  "success_url": "/",
+  "success_url": "/stormpath-id-site-callback",
   "addons": [
     "oauthio",
     "stormpath"

--- a/app.json
+++ b/app.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/avojnovicDk/stormpath-django-sample",
   "logo": "http://docs.stormpath.com/images/heroku/stormpath-icon.svg",
   "keywords": ["django", "stormpath", "heroku", "sample"],
+  "success_url": "/",
   "addons": [
     "oauthio",
     "stormpath"

--- a/app.json
+++ b/app.json
@@ -1,22 +1,11 @@
 {
   "name": "stormpath-django sample",
   "description": "Example application demonstrating how to use the Django plugin for Stormpath",
-  "repository": "https://github.com/stormpath/stormpath-django-sample",
+  "repository": "https://github.com/avojnovicDk/stormpath-django-sample",
   "logo": "http://docs.stormpath.com/images/heroku/stormpath-icon.svg",
   "keywords": ["django", "stormpath", "heroku", "sample"],
-  "env": {
-      "STORMPATH_API_KEY_ID": {
-          "description": "Stormpath API key ID."
-      },
-      "STORMPATH_API_KEY_SECRET": {
-          "description": "Stormpath API key secret."
-      },
-      "STORMPATH_APPLICATION": {
-          "description": "Stormpath application href."
-      },
-      "STORMPATH_ID_SITE_CALLBACK_URI": {
-          "description": "Stormpath callback uri for ID Site.",
-          "required": false
-      }
-  }
+  "addons": [
+    "oauthio",
+    "stormpath"
+  ]
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,22 @@
+{
+  "name": "stormpath-django sample",
+  "description": "Example application demonstrating how to use the Django plugin for Stormpath",
+  "repository": "https://github.com/stormpath/stormpath-django-sample",
+  "logo": "http://docs.stormpath.com/images/heroku/stormpath-icon.svg",
+  "keywords": ["django", "stormpath", "heroku", "sample"],
+  "env": {
+      "STORMPATH_API_KEY_ID": {
+          "description": "Stormpath API key ID."
+      },
+      "STORMPATH_API_KEY_SECRET": {
+          "description": "Stormpath API key secret."
+      },
+      "STORMPATH_APPLICATION": {
+          "description": "Stormpath application href."
+      },
+      "STORMPATH_ID_SITE_CALLBACK_URI": {
+          "description": "Stormpath callback uri for ID Site.",
+          "required": false
+      }
+  }
+}

--- a/project/settings.py
+++ b/project/settings.py
@@ -33,7 +33,7 @@ DATABASES = {
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -183,11 +183,15 @@ AUTH_USER_MODEL = 'django_stormpath.StormpathUser'
 STORMPATH_ID = os.environ['STORMPATH_API_KEY_ID']
 STORMPATH_SECRET = os.environ['STORMPATH_API_KEY_SECRET']
 STORMPATH_APPLICATION = os.environ['STORMPATH_APPLICATION']
-
-STORMPATH_ID_SITE_CALLBACK_URI = 'http://localhost:8000/stormpath-id-site-callback'
+STORMPATH_ID_SITE_CALLBACK_URI = os.environ.get(
+    'STORMPATH_ID_SITE_CALLBACK_URI')
 
 LOGIN_REDIRECT_URL = '/'
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 USE_ID_SITE = True
+
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+ALLOWED_HOSTS = ['*']

--- a/project/wsgi.py
+++ b/project/wsgi.py
@@ -25,7 +25,9 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
 from django.core.wsgi import get_wsgi_application
-application = get_wsgi_application()
+from dj_static import Cling
+
+application = Cling(get_wsgi_application())
 
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 django-stormpath>=0.0.7
+django-toolbelt==0.0.1

--- a/sample/views.py
+++ b/sample/views.py
@@ -33,7 +33,7 @@ def stormpath_login(request):
         user = form.get_user()
         login(request, user)
         return redirect('sample:home')
-    print form.errors
+
     return render(
         request, 'login.html', {"form": form, 'id_site': settings.USE_ID_SITE})
 


### PR DESCRIPTION
Hey @rdegges!
I added Heroku button (issue #6 ) and tested sample app deployed with that button. For some reason, I can't get ID site to work. I get error from Stormpath: "jwtBody cb_uri is an invalid value.". I'm setting the callback URI as environment variable STORMPATH_ID_SITE_CALLBACK_URI to "http://MY_HEROKU_APP.herokuapp.com/stormpath-id-site-callback" . It works with localhost, do you have an idea why it wouldn't work on Heroku?