### PR TITLE
Added Heroku deploy button.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn project.wsgi --log-file -

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
 stormpath-django-sample
 =======================
 
@@ -18,6 +20,7 @@ Stormpath Django required you to have these environment variables set:
     STORMPATH_API_KEY_ID = "apiKeyId"
     STORMPATH_API_KEY_SECRET = "apiKeySecret"
     STORMPATH_APPLICATION = "https://api.stormpath.com/v1/applications/APP_ID"
+    STORMPATH_ID_SITE_CALLBACK_URI = "http://localhost:8000/stormpath-id-site-callback"
 
 You need to make sure database and other standard Django settings are correct.
 E.g. Chirper has to be specified in INSTALLED_APPS of the project.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "name": "stormpath-django sample",
+  "description": "Example application demonstrating how to use the Django plugin for Stormpath",
+  "repository": "https://github.com/stormpath/stormpath-django-sample",
+  "logo": "http://docs.stormpath.com/images/heroku/stormpath-icon.svg",
+  "keywords": ["django", "stormpath", "heroku", "sample"],
+  "success_url": "/",
+  "addons": [
+    "stormpath"
+  ]
+}

--- a/project/settings.py
+++ b/project/settings.py
@@ -19,21 +19,15 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
+import dj_database_url
+
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',  # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'sample.db',  # Or path to database file if using sqlite3.
-        # The following settings are not used with sqlite3:
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': '',  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        'PORT': '',  # Set to empty string for default.
-    }
+    'default': dj_database_url.config()
 }
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -182,12 +176,17 @@ AUTH_USER_MODEL = 'django_stormpath.StormpathUser'
 # stormpath-django
 STORMPATH_ID = os.environ['STORMPATH_API_KEY_ID']
 STORMPATH_SECRET = os.environ['STORMPATH_API_KEY_SECRET']
-STORMPATH_APPLICATION = os.environ['STORMPATH_APPLICATION']
+# stormpath Heroku addon sets STORMPATH_URL environment variable
+STORMPATH_APPLICATION = os.environ.get(
+    'STORMPATH_APPLICATION', os.environ.get('STORMPATH_URL'))
 
-STORMPATH_ID_SITE_CALLBACK_URI = 'http://localhost:8000/stormpath-id-site-callback'
+STORMPATH_ID_SITE_CALLBACK_URI = os.environ.get(
+    'STORMPATH_ID_SITE_CALLBACK_URI')
 
 LOGIN_REDIRECT_URL = '/'
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 USE_ID_SITE = True
+
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/project/wsgi.py
+++ b/project/wsgi.py
@@ -25,7 +25,8 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
 from django.core.wsgi import get_wsgi_application
-application = get_wsgi_application()
+from dj_static import Cling
+application = Cling(get_wsgi_application())
 
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 django-stormpath>=0.0.7
+django-toolbelt==0.0.1
+dj-database-url==0.3.0


### PR DESCRIPTION
This is a new PR for issue #6. I tested deploy with "Deploy to Heroku" button and everything works after applying Django migrations, setting STORMPATH_ID_SITE_CALLBACK_URI to "https://MY_HEROKU_APP.herokuapp.com/stormpath-id-site-callback" and listing that URL as authorized redirect URL in ID Site configuration.